### PR TITLE
Keep "nightwind" class only while transitioning

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -16,13 +16,20 @@ module.exports = {
                 return 'light';
         }
         getInitialColorMode() == 'light' ? document.documentElement.classList.remove('dark') : document.documentElement.classList.add('dark');
-        document.documentElement.classList.add('nightwind');
       })()
     `;
     return codeToRunOnClient;
   },
 
   toggle: () => {
+    if (!document.documentElement.classList.contains('nightwind')) {
+      const handler = () => {
+        document.documentElement.classList.remove('nightwind');
+        document.documentElement.removeEventListener('transitionend', handler)
+      }
+      document.documentElement.addEventListener('transitionend', handler)
+      document.documentElement.classList.add('nightwind');
+    }
     if (!document.documentElement.classList.contains('dark')) {
       document.documentElement.classList.add('dark');
       window.localStorage.setItem('nightwind-mode', 'dark');

--- a/helper.js
+++ b/helper.js
@@ -20,16 +20,21 @@ module.exports = {
     `;
     return codeToRunOnClient;
   },
+  
+  beforeTransition: () => {
+    const doc = document.documentElement;
+    const onTransitionDone = () => {
+      doc.classList.remove('nightwind');
+      doc.removeEventListener('transitionend', onTransitionDone);
+    }
+    doc.addEventListener('transitionend', onTransitionDone);
+    if (!doc.classList.contains('nightwind')) {
+      doc.classList.add('nightwind');
+    }
+  },
 
   toggle: () => {
-    if (!document.documentElement.classList.contains('nightwind')) {
-      const handler = () => {
-        document.documentElement.classList.remove('nightwind');
-        document.documentElement.removeEventListener('transitionend', handler)
-      }
-      document.documentElement.addEventListener('transitionend', handler)
-      document.documentElement.classList.add('nightwind');
-    }
+    module.exports.beforeTransition();
     if (!document.documentElement.classList.contains('dark')) {
       document.documentElement.classList.add('dark');
       window.localStorage.setItem('nightwind-mode', 'dark');


### PR DESCRIPTION
This fixes unwanted transitions as a side-effect of having `nightwind` class at html tag.
It's a quick fix that does not touch anything below "// OLD " comment.