### PR TITLE
Better support for default dark pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ export default function Layout() {
 }
 ```
 
+We know some people want to convert their dark mode apps to work with light mode as well, so instead of using `<script dangerouslySetInnerHTML={{ __html: nightwind.init() }} />` you'll use `<script dangerouslySetInnerHTML={{ __html: nightwind.init(true) }} />`.
+
 ### Toggle
 
 Similarly, you can use the `toggle` function to switch between dark and light mode.

--- a/helper.js
+++ b/helper.js
@@ -1,5 +1,5 @@
 module.exports = {
-  init: () => {
+  init: (defualtDark) => {
     const codeToRunOnClient = `
       (function() {
         function getInitialColorMode() {
@@ -11,9 +11,17 @@ module.exports = {
                 const mql = window.matchMedia('(prefers-color-scheme: dark)');
                 const hasMediaQueryPreference = typeof mql.matches === 'boolean';
                 if (hasMediaQueryPreference) {
-                  return mql.matches ? 'dark' : 'light';
+                  if (defualtDark) {
+                    return mql.matches ? 'light' : 'dark';
+                  } else {
+                    return mql.matches ? 'dark' : 'light';
+                  }
                 }
-                return 'light';
+                if (defualtDark) {
+                  return 'dark';
+                } else {
+                  return 'light';
+                }
         }
         getInitialColorMode() == 'light' ? document.documentElement.classList.remove('dark') : document.documentElement.classList.add('dark');
       })()


### PR DESCRIPTION
When I normally make apps, I choose a color scheme and get to work in dark mode before using light mode. Unfortunately, using a tool light Nightwind is made for light mode apps that want to add dark functionality. The main thing it breaks is the default theme for computers, where it goes to light for dark theme and vice versa. 

To remedy this, I've added a statement where you can add "true" (like this `<script dangerouslySetInnerHTML={{ __html: nightwind.init(true) }} />`) to make it work like intended. I have no idea if this will actually work, and I don't know how to/can't test it.