### PR TITLE
Windi css support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -306,9 +306,9 @@ const nightwind = plugin(
 
     if (theme("nightwind.typography")) {
       Object.keys(theme("typography")).forEach((modifier) => {
-        Object.keys(theme(`typography.${modifier}.css`)).forEach((n) => {
+        Object.keys(theme(`typography.${modifier}.css`) ?? {}).forEach((n) => {
           const themeParser = JSON.parse(
-            JSON.stringify(theme(`typography.${modifier}.css[${n}]`))
+            JSON.stringify(theme(`typography.${modifier}.css`)[n])
           )
           Object.keys(themeParser).forEach((classname) => {
             const themeClass = themeParser[classname]


### PR DESCRIPTION
For a projet I happend to use [Windi css](https://windicss.org/) instead of tailwind and have made a small patch for this nightwind to work with it. I give it to you if you want to support it in the future.

Here is my `windi.config.js` if you want to try for yourselves
```
import { defineConfig, transform } from 'windicss/helpers'

export default defineConfig({
	darkMode: 'class',
	theme: {
		nightwind: {
			typography: true,
		},
	},
	plugins: [
		require('windicss/plugin/typography'),
		transform('nightwind')
	]
});
```